### PR TITLE
Update coverpage template 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
+* * *
+
+**JIRA Ticket**: (link)
+
+* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
+
+# What does this Pull Request do?
+A brief description of what the intended result of the PR will be and/or what problem it solves.
+
+# How should this be tested?
+
+A description of what steps someone could take to:
+* Reproduce the problem you are fixing (if applicable)
+* Test that the Pull Request does what is intended.
+* Please be as detailed as possible.
+* Good testing instructions help get your PR completed faster.
+
+# Test coverage
+Yes/No: Are changes in this pull-request covered by:
+- unit tests?
+- integration tests?
+
+# Interested parties
+Tag (@ mention) interested parties

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 web/node_modules
 dist
 lib
+.vscode

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This fork of PDIIIF is intended to be used for developing a customized coverpage
 2. `harvard-main` is the default branch, and is intended to keep commits dealing with Harvard specific changes out of `main`. Merge in `main` in order to pull in upstream changes and resolve any conflicts.
 3. Create a feature branch for new tickets using the Jira ticket ID. Once complete open a PR against `harvard-main`
 
+**When creating a PR make sure to change the base repository to "harvard-lts/pdiiif"**. [Lots of people make this mistake, and it isn't configurable yet](https://github.com/orgs/community/discussions/11729).
+
 ## The role of Docker in this project
 
 Seems like it's primarily to provide the back-end service locally _however_, the web app is also accessible via the same port (`http://localhost:8080`).

--- a/pdiiif-api/assets/coverpage.hbs
+++ b/pdiiif-api/assets/coverpage.hbs
@@ -88,24 +88,12 @@
         z-index: 500;
         max-width: 190pt;
         background-color: white;
-      }
-
-      .manifest-link figcaption {
         font-size: 8pt;
       }
 
-      .manifest-link svg {
-        max-width: 128pt;
-      }
-
-      .pdiiif-logo svg {
-        margin-left: 8pt;
-        max-height: 128pt;
-      }
-
-      .logo-container {
-        display: flex;
-        align-items: flex-end;
+      .pdiiif-credit {
+        font-size: 8pt;
+        margin-right: 8pt;
       }
 
       .main {
@@ -128,7 +116,9 @@
         bottom: 0;
         display: flex;
         flex-direction: row;
+        align-items: flex-end;
         width: 100%;
+        gap: 8pt;
         justify-content: space-between;
         page-break-before: auto;
         page-break-after: auto;
@@ -164,28 +154,8 @@
         {{#if thumbUrl}}
           <img class="preview" src="{{thumbUrl}}" alt="Preview Image" />
         {{/if}}
-        {{#if providerLogo}}
-          <figure class="attribution">
-            {{#if providerLink}}
-            <a href="{{providerLink}}">
-              <img class="logo" src="{{providerLogo}}" />
-            </a>
-            {{else}}
-            <img class="logo" src="{{providerLogo}}" />
-            {{/if}}
-            {{#if providerText}}
-              <figcaption>
-                {{#if providerLink}}
-                  <a href="{{providerLink}}">
-                    {{providerText}}
-                  </a>
-                {{else}}
-                  {{providerText}}
-                {{/if}}
-              </figcaption>
-            {{/if}}
-          </figure>
-        {{else if providerText}}
+
+        {{#if providerText}}
           <p>
             {{#if providerLink}}
               <a href="{{providerLink}}">
@@ -196,6 +166,7 @@
             {{/if}}
           </p>
         {{/if}}
+
         {{#if rightsLogo}}
           <figure class="license">
             {{#if rightsLink}}
@@ -266,66 +237,17 @@
       </div>
     </main>
     <footer>
-      <figure class="manifest-link">
+      <p class="manifest-link">
         <a href="{{manifestUrl}}">
-          {{#qrcode manifestUrl width=96 height=96}}{{/qrcode}}
+          {{manifestUrl}}
         </a>
-        <figcaption>
-          <a href="{{manifestUrl}}">
-            {{manifestUrl}}
-          </a>
-        </figcaption>
-      </figure>
-      <figure class="pdiiif-logo">
-        <div class="logo-container">
-          <strong class="prefix">
-            Created with
-          </strong>
-          {{! pdiiif logo }}
-          <a href="https://pdiiif.jbaiter.de">
-          <svg xmlns="http://www.w3.org/2000/svg" width="47" height="58">
-            <path
-              fill="#ee2635"
-              d="M3.91968.000001H36.9019L47.078 9.33807V54.8913c0 2.1715-1.7482 3.9197-3.9197 3.9197H3.91968C1.74818 58.811 0 57.0628 0 54.8913V3.91968C0 1.74818 1.74818.000001 3.91968.000001Z"
-            ></path>
-            <path
-              fill="#fff"
-              d="M4.70707 46.6718v5.0279H2.04989V37.4161h4.64266c.95487 0 1.78133.112 2.47937.3359.69805.2239 1.27428.5367 1.72868.9384.4544.4017.7902.8824 1.0075 1.4422.2239.5597.3359 1.1722.3359 1.8373 0 .6915-.1153 1.3269-.3457 1.9064-.2305.573-.5763 1.0669-1.0372 1.4818-.461.4148-1.04052.7375-1.73857.968-.69146.2305-1.50145.3457-2.42998.3457Zm0-2.0744h1.98548c.48731 0 .91206-.0592 1.27426-.1777.36219-.1252.66182-.2997.8989-.5236.24365-.2305.42475-.5071.54329-.8297.11853-.3293.1778-.6948.1778-1.0965 0-.3819-.05927-.7277-.1778-1.0372-.11854-.3095-.29634-.5729-.53342-.7902-.23707-.2173-.5367-.382-.89889-.4939-.3622-.1186-.79024-.1778-1.28414-.1778H4.70707Zm21.68893-.0395c0 1.0471-.1745 2.0086-.5236 2.8844-.349.8759-.8396 1.6299-1.4718 2.2621-.6322.6322-1.3928 1.1228-2.2818 1.4718s-1.8768.5235-2.9634.5235h-5.4428V37.4161h5.4428c1.0866 0 2.0744.1778 2.9634.5334.889.3491 1.6496.8397 2.2818 1.4719.6322.6256 1.1228 1.3763 1.4718 2.2522.3491.8758.5236 1.8373.5236 2.8843Zm-2.7263 0c0-.7836-.1054-1.485-.3161-2.104-.2042-.6256-.5038-1.1524-.8989-1.5805-.3886-.4346-.8627-.7672-1.4225-.9976-.5531-.2305-1.1787-.3458-1.8768-.3458h-2.7757v10.0558h2.7757c.6981 0 1.3237-.1152 1.8768-.3457.5598-.2305 1.0339-.5597 1.4225-.9878.3951-.4346.6947-.9615.8989-1.5805.2107-.6256.3161-1.3302.3161-2.1139Z"
-              aria-label="PD"
-            ></path>
-            <path fill="#fff" d="M27.551 35.689h21.663v18.275H27.551Z"></path>
-            <path
-              fill="none"
-              stroke="#fff"
-              stroke-width=".264583"
-              d="M36.9019.000001V9.47155l10.1761-.13348"
-            ></path>
-            <path
-              fill="#2873ab"
-              d="m29.1672 42.3338 3.382 1.2564-.006 9.0503-3.376-1.2444Zm3.5196-2.1975c.388 1.1475-.1261 2.0778-1.1481 2.0778-1.022 0-2.165-.9303-2.553-2.0778-.3879-1.1474.1262-2.0777 1.1482-2.0777 1.0221 0 2.165.9303 2.5529 2.0777"
-            ></path>
-            <path
-              fill="#ed1d33"
-              d="m36.8521 42.3338-3.382 1.2564.0059 9.0503 3.3761-1.2444Zm-3.5416-2.1975c-.3879 1.1475.1262 2.0778 1.1482 2.0778s2.165-.9303 2.553-2.0778c.3878-1.1474-.1262-2.0777-1.1482-2.0777-1.0221 0-2.165.9303-2.553 2.0777"
-            ></path>
-            <path
-              fill="#2873ab"
-              d="m37.7174 42.3338 3.382 1.2564-.006 9.0503-3.376-1.2444Zm3.5416-2.1975c.3879 1.1475-.1261 2.0778-1.1482 2.0778s-2.165-.9303-2.5529-2.0778c-.388-1.1474.1261-2.0777 1.1481-2.0777 1.0221 0 2.165.9303 2.553 2.0777"
-            ></path>
-            <path
-              fill="#ed1d33"
-              d="M46.482 36.9453v3.1081s-1.0956-.4287-1.2266.6787c-.0119 1.179 0 1.6017 0 1.6017l1.2266-.3989v2.727l-1.2319.4406v6.3591l-3.3648 1.2504V41.4705s-.0714-4.0489 4.5967-4.5252"
-            ></path>
-          </svg>
+      </p>
+      <p class="pdiiif-credit">
+        Created with PDIIIF<br />
+        <a href="https://pdiiif.jbaiter.de">
+          https://pdiiif.jbaiter.de
         </a>
-        </div>
-        <figcaption>
-          <div class="version">v{{pdiiifVersion}}</div>
-          <a href="https://pdiiif.jbaiter.de">
-            https:/pdiiif.jbaiter.de
-          </a>
-        </figcaption>
-      </figure>
+      </p>
     </footer>
     <script>
       const mainElem = document.querySelector('main');


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-158](https://jira.huit.harvard.edu/browse/LTSVIEWER-158)

- [mps-viewer companion PR](https://github.com/harvard-lts/mps-viewer/pull/54)
- [Mirador PDIIIF Plugin](https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/8)

# What does this Pull Request do?
Takes the sample containerised coverpage API endpoint service from PDIIIF and updates the handlebars template to tailor Harvard specifications.

# How should this be tested?

1. Checkout this branch in this repository
2. Follow the ["Quickstart"](https://github.com/harvard-lts/pdiiif/tree/LTSVIEWER-158#quickstart) instructions to get the Docker container up and running. You should be able to access the local server at `http://localhost:8080/`
3. Checkout the [mps-viewer companion PR](https://github.com/harvard-lts/mps-viewer/pull/54) locally.
4. Restarting the mps-viewer container should install the latest version of the PDIIIF plugin.
5. Update the config in `mirador.js`, inside `miradorPDIIIIFPlugin` add a new property: `coverPageEndpoint: 'http://localhost:8080/api/coverpage'`
6. Shell into the container with `docker exec -it mps-viewer bash` and run `npm run webpack` to compile the changes 
7. Now visit one of the legacy example PTO's on your local environment in your browser
8. When downloading a PDF, you should see that the cover page looks different from QA.
    - There should be no Harvard logo
    - There should be no PDIIIF logo
    - There should be no QR code


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 