### PR TITLE
Add docker-compose-local.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ web/node_modules
 dist
 lib
 .vscode
+
+# Configuration files
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN cd pdiiif-lib && \
     pnpm i && pnpm run build && \
     rm -rf ~/.pnpm-store
 
-ENV CFG_PORT 23024
+ENV CFG_PORT 8080
 ENV CFG_HOST 0.0.0.0
 
 EXPOSE ${CFG_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,4 @@ ENV CFG_HOST 0.0.0.0
 EXPOSE ${CFG_PORT}
 
 WORKDIR /opt/pdiiif/pdiiif-api
-
 CMD ["node", "dist/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,11 @@ RUN cd pdiiif-lib && \
     pnpm i && pnpm run build && \
     rm -rf ~/.pnpm-store
 
-ENV CFG_PORT 8080
+ENV CFG_PORT 23024
 ENV CFG_HOST 0.0.0.0
 
 EXPOSE ${CFG_PORT}
 
 WORKDIR /opt/pdiiif/pdiiif-api
+
 CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ $ docker build . -t pdiiif
 $ docker run -p 8080:8080 --cap-add=SYS_ADMIN --name pdiiif pdiiif
 ```
 
+To use the docker-compose-local.yml file:
+
+```
+docker-compose -f docker-compose-local.yml up -d --build --force-recreate
+```
+
 ## Cookbook Matrix
 
 The [IIIF Cookbook](https://iiif.io/api/cookbook/) has a matrix of "recipes" with viewer support, here's an overview

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -9,9 +9,6 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    env_file: .env
-    volumes:
-      - './:/opt/pdiiif'
     ports:
       - "23024:8080"
     # Join this service to a custom docker network

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -9,6 +9,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+    env_file: .env
     ports:
       - "23024:8080"
     # Join this service to a custom docker network

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,24 @@
+# Build all images and start all containers: `docker compose -f docker-compose-local.yml build --no-cache && docker compose -f docker-compose-local.yml up -d`
+# Start containers only: `docker compose -f docker-compose-local.yml up -d`
+# Stop and remove all containers: `docker compose -f docker-compose-local.yml down`
+
+version: '3.7'
+services:
+  app:
+    container_name: mps-pdiiif
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    env_file: .env
+    volumes:
+      - './:/opt/pdiiif'
+    ports:
+      - "23024:8080"
+    # Join this service to a custom docker network
+    networks:
+      - mps-net
+
+  # Create a custom docker network if it does not exist already
+networks:
+  mps-net:
+    name: mps-net

--- a/env-example.txt
+++ b/env-example.txt
@@ -1,0 +1,2 @@
+# Environment 'development', 'test', or 'production'
+ENV=development

--- a/pdiiif-api/src/coverpage.ts
+++ b/pdiiif-api/src/coverpage.ts
@@ -105,7 +105,7 @@ export class CoverPageGenerator {
     this.browser = await puppeteer.launch({
       product: 'chrome',
       headless: 'new',
-      args: ['--font-render-hinting=none', '--force-color-profile=srgb'],
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--font-render-hinting=none', '--force-color-profile=srgb'],
       executablePath: process.env.CFG_PUPPETEER_BROWSER_EXECUTABLE,
     });
     const tmpl = await fs.readFile(this.coverTemplatePath);


### PR DESCRIPTION
**Add docker-compose-local.yml**
* * *

**JIRA Ticket**: [LTSVIEWER-218](https://jira.huit.harvard.edu/browse/LTSVIEWER-218)

# What does this Pull Request do?
This adds a docker-compose-local.yml file so that you can run this using our normal build process. It also sets it to use port 23024, which is the port that will be used on LTS Cloud servers.

# How should this be tested?

A description of what steps someone could take to:
* Pull in the latest code form `LTSVIEWER-203` branch
* Copy the `env-example.txt` to `.env` (You don't have to make any changes to the file)
* Build the container using the following command: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
* Confirm that you can get to the application at: http://localhost:23024
* Confirm that you can generate a PDF using curl: 
`curl -X POST 'http://localhost:23024/api/coverpage' \
   -H 'Content-Type: application/json' \
   -d '{"title":"Lee, Joseph. Hot dog in the manger. [Boston : Massachusetts Civic League, 1928?].","manifestUrl":"https://iiif.lib.harvard.edu/manifests/drs:4997399","pdiiifVersion":"0.1.0git","thumbnail":{"url":"https://ids.lib.harvard.edu/ids/iiif/4997393/full/200,/0/default.jpg"},"provider":{"label":"","logo":"https://iiif.lib.harvard.edu/static/manifests/harvard_logo.jpg"},"metadata":[["Rights/License","http://nrs.harvard.edu/urn-3:hul.ois:hlviewerterms"]]}' \
  --compressed \
  -o test.pdf`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 